### PR TITLE
Add Governance page

### DIFF
--- a/_pages/governance.md
+++ b/_pages/governance.md
@@ -1,0 +1,207 @@
+---
+layout: jumbotron-container
+title: Governance
+permalink: /governance/
+description: |-
+  As the OpenAMP Project governance gets defined, it will be documented here.
+
+  Governance discussions are typicaly held during the OpenAMP Technical Steering Committee meetings.
+jumbotron:
+    triangle-divider: true
+    title: Governance
+    description: >
+        As the OpenAMP Project governance gets defined, it will be documented here.
+        Governance discussions are typicaly held during the OpenAMP Technical Steering Committee meetings.
+    background-image: /assets/images/content/triangle_background.svg
+---
+# Introduction
+
+As the OpenAMP Project governance gets defined, it will be documented here.
+Governance discussions are typicaly held during the OpenAMP Technical Steering Committee meetings.
+
+# Strategic and Technical Direction
+## Board
+
+The OpenAMP Project board consists of a representative from each of the member companies.  For more details regarding the Board, please refer to the [Project Charter][Project Charter].
+
+## Technical Steering Committee
+
+The Technical Steering Committee (TSC) calls are open to all.  Items requiring a vote are voted upon by a representative from each of the member companies.  To be notified of TSC calls, please subscribe to the TSC mailing list [via the OpenAMP Project mailing lists page][OpenAMP mailing lists page].
+
+For more details regarding the TSC, please refer to the [Project Charter][Project Charter].
+
+## Working Groups
+
+The OpenAMP Working Groups are currently:
+* OpenAMP Remoteproc (a.k.a. OpenAMP classic)
+* System Device Tree
+* Application Services
+
+To be notified of working group calls, please subscribe to the corresponding working group mailing list [via the OpenAMP Project mailing lists page][OpenAMP mailing lists page].
+
+# Membership
+
+It is not a requirement to be employed at a Member company to participate as a developer or in the OpenAMP Technical Steering Committee. Community participation is welcome!
+
+Governance of the community project is overseen by a board of representatives from Member companies. Member fees support administration for the project, such as the project website and mailing lists. Details can be found in the [Project Charter][Project Charter].
+
+To get more information about membership, contact [enquiries@openampproject.org](mailto:enquiries@openampproject.org "Enquiries email")
+
+# Consensus and Conflict Resolution
+
+To be discussed at October 2020 TSC call.
+
+# Code of Conduct
+
+OpenAMP Board is in process of working on modified version of the CHAOSS code of conduct.  That will need to be voted upon to be adopted.
+
+We are looking for a couple volunteers to be part of the Code of Conduct Committee.  Please contact [the board](mailto:board@lists.openampproject.org "E-mail OpenAMP Board") if you are interested.
+
+# Development Process
+
+## Maintainers
+
+Maintainers are nominated and voted upon by the TSC.  They should be the only ones who can commit to the repositories.  As with everyone else, they are to use Pull Requests.
+
+[Arnaud][Arnaud Github] and [Ed][Ed Github] are the maintainers of [libmetal][libmetal Github] and lib [open-amp][open-amp Github]. (2020-02-20)
+
+## Coding Standards
+
+### Coding Style
+
+OpenAMP uses the [Zephyr coding style][Zephyr coding style] and has the checkpatch.pl from Zephyr script as part of its continuous integration process.  (2020-02-20)
+
+### MISRA C
+(2020-04-17) There was some interest in making the code easier to certify, but no firm decision to proceed.  Recommendation is to watch what Zephyr and Xen do, then revisit the question.
+
+### C Version
+
+To be discussed.  C11?
+
+## Development Workflow
+
+All development will be done using the standard GitHub workflow of pull requests. (2020-02-20)
+
+### Bug Tracking
+
+Via GitHub issues. (2020-05-12)
+
+### Commit Process
+
+Pull requests will be merged by the maintainers after review.
+
+### New Feature Development
+
+Proposed new features should be discussed actively on the mailing list and the top features selected for the next release. The Technical Steering Committee and Working Groups can also provide direction on feature development.
+
+### Testing
+
+For a new feature, an application or test must be provided so that we can test that the feature works & continues to be valid in the future.
+
+Travis CI has Zephyr checkpatch.
+
+TO DO: Add guidelines once they get baked
+
+### Documentation
+
+Sphinx was proposed and is under consideration (2020-05-12) 
+
+Topic to be revisited.
+
+## Branching and Tagging Strategy
+
+### Development on master
+
+The master branch is where all accepted changes are first committed. The CI loop is primarily focused on this branch.
+
+### Release branches
+
+A release branch is created from the master branch at the time of feature freeze for the release.
+
+### Release Tags
+
+At the time of the release, the release branch will be tagged. This will help enable reproducible builds.
+
+## Releases
+
+### Release Frequency
+
+Releases will be twice yearly, in the spring and fall (usually mid-April and mid-October).
+
+### Naming Conventions
+
+Releases will be named yyyy.mm (e.g. 2019.10).
+
+### Release Process
+
+As the OpenAMP project is rather small as open-source projects go, the release process can be fairly simple. The phases and milestones are listed below. This information should be maintained on the Wiki page for the project.
+
+#### Discussion and Development
+
+This is for discussion and development of new features. It starts as soon as the release branch is created. During this period, new features can be committed after the usual review.
+
+#### Feature Freeze
+
+This occurs at about the four-month mark in the release cycle. The release branch is created from the master at this point.
+
+#### Debug
+
+After Feature Freeze, no new features can be committed to the release branch, only bug fixes.
+
+#### Code Freeze
+
+At this time, no further commits may be made to the release branch unless they fix a critical bug found in testing.
+
+#### Release
+
+The release branch is tagged and the code archived and made accessible for download.
+
+#### Release Maintenance
+
+See [https://wiki.yoctoproject.org/wiki/Stable_branch_maintenance](https://wiki.yoctoproject.org/wiki/Stable_branch_maintenance)
+
+## Interface Stability Policy
+
+### API Stability
+
+#### Scope
+
+The scope of the OpenAMP API lifecycle policy is mostly the libraries and supporting code owned by the project. Today that is primarily the open-amp and libmetal libraries but we expect that to expand in the future.
+
+Specifically out of scope would be the APIs internal to the Linux kernel.  The Linux kernel has a famous "no stable api" policy. Probably also out of scope would be the kernel / user interface.  This interface has a more stringent "don't break the user interface policy" than will be described here.
+
+#### Adding New APIs
+
+TBD
+
+#### Deprecating Existing APIs
+
+If an API is to be removed, it must remain in a deprecated state for 2 year (4 releases). In extraordinary cases such as a critical security issue, the TSC may impose a shorter period.
+
+#### Kernel vs. Library Compatibility
+
+The kernel and library implementations of OpenAMP must be interoperable at all times. Extensions on either side must be  downward compatible.
+
+### Wire Protocol Stability
+
+The wire protocol describes the interactions of two independent CPUs in an AMP system.  The bar for maintaining compatibility at this level is much higher.
+
+This is being discussed on the TSC mailing list in the [thread "API and Wire protocol stability"](https://lists.openampproject.org/pipermail/tsc/2020-May/000062.html).
+
+## Certification Concerns
+
+### Safety
+
+TBD
+
+### Security
+
+TBD
+
+[OpenAMP mailing lists page]: http://lists.openampproject.org
+[Project Charter]: ../docs/OpenAMPProject_Charter_Approved2020Mar06BoardMeeting.pdf
+[Arnaud Github]: https://github.com/arnopo
+[Ed Github]: https://github.com/edmooring
+[libmetal Github]: https://github.com/OpenAMP/libmetal
+[open-amp Github]: https://github.com/OpenAMP/open-amp
+[Zephyr coding style]: https://docs.zephyrproject.org/latest/contribute/index.html#coding-style

--- a/_pages/governance.md
+++ b/_pages/governance.md
@@ -5,19 +5,19 @@ permalink: /governance/
 description: |-
   As the OpenAMP Project governance gets defined, it will be documented here.
 
-  Governance discussions are typicaly held during the OpenAMP Technical Steering Committee meetings.
+  Governance discussions are typically held during the OpenAMP Technical Steering Committee meetings.
 jumbotron:
     triangle-divider: true
     title: Governance
     description: >
         As the OpenAMP Project governance gets defined, it will be documented here.
-        Governance discussions are typicaly held during the OpenAMP Technical Steering Committee meetings.
+        Governance discussions are typically held during the OpenAMP Technical Steering Committee meetings.
     background-image: /assets/images/content/triangle_background.svg
 ---
 # Introduction
 
 As the OpenAMP Project governance gets defined, it will be documented here.
-Governance discussions are typicaly held during the OpenAMP Technical Steering Committee meetings.
+Governance discussions are typically held during the OpenAMP Technical Steering Committee meetings.
 
 # Strategic and Technical Direction
 ## Board
@@ -53,7 +53,7 @@ To be discussed at October 2020 TSC call.
 
 # Code of Conduct
 
-OpenAMP Board is in process of working on modified version of the CHAOSS code of conduct.  That will need to be voted upon to be adopted.
+The OpenAMP Board is in the process of working on a modified version of the CHAOSS code of conduct.  That will need to be voted upon to be adopted.
 
 We are looking for a couple volunteers to be part of the Code of Conduct Committee.  Please contact [the board](mailto:board@lists.openampproject.org "E-mail OpenAMP Board") if you are interested.
 
@@ -61,15 +61,15 @@ We are looking for a couple volunteers to be part of the Code of Conduct Committ
 
 ## Maintainers
 
-Maintainers are nominated and voted upon by the TSC.  They should be the only ones who can commit to the repositories.  As with everyone else, they are to use Pull Requests.
+Maintainers are nominated and voted upon by the TSC.  They should be the only ones who can commit to the repositories.  As with everyone else, they must use Pull Requests.
 
-[Arnaud][Arnaud Github] and [Ed][Ed Github] are the maintainers of [libmetal][libmetal Github] and lib [open-amp][open-amp Github]. (2020-02-20)
+[Arnaud Pouliquen][Arnaud Github] and [Ed Mooring][Ed Github] are the maintainers of [libmetal][libmetal Github] and lib [open-amp][open-amp Github]. (2020-02-20)
 
 ## Coding Standards
 
 ### Coding Style
 
-OpenAMP uses the [Zephyr coding style][Zephyr coding style] and has the checkpatch.pl from Zephyr script as part of its continuous integration process.  (2020-02-20)
+OpenAMP uses the [Zephyr coding style][Zephyr coding style] and uses the checkpatch.pl script to automatically review and leave comments on pull requests (continuous integration process). (2020-02-20)
 
 ### MISRA C
 (2020-04-17) There was some interest in making the code easier to certify, but no firm decision to proceed.  Recommendation is to watch what Zephyr and Xen do, then revisit the question.
@@ -98,7 +98,7 @@ Proposed new features should be discussed actively on the mailing list and the t
 
 For a new feature, an application or test must be provided so that we can test that the feature works & continues to be valid in the future.
 
-Travis CI has Zephyr checkpatch.
+OpenAMP CI is relying on the checkpatch tool, using Zephyr coding rules.
 
 TO DO: Add guidelines once they get baked
 
@@ -157,6 +157,8 @@ At this time, no further commits may be made to the release branch unless they f
 The release branch is tagged and the code archived and made accessible for download.
 
 #### Release Maintenance
+
+Topic to be revisited.
 
 See [https://wiki.yoctoproject.org/wiki/Stable_branch_maintenance](https://wiki.yoctoproject.org/wiki/Stable_branch_maintenance)
 


### PR DESCRIPTION
This page replaces Ed's governance MS Word document that we were
working on revising.  Having the governance in GitHub makes it
easier to reference and update, as the TSC meets, discusses & makes
decisions.

NOTE: It is not linked to yet from the main website. You need to know
the link to find it.  Keeping it semi-hidden until it has a chance for
review & cleanup by the TSC.  Having it in Markdown makes it easier 
for people to suggest changes via pull request.