### PR TITLE
Add lopper to page footer

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -23,6 +23,8 @@ second-column:
         url: https://github.com/OpenAMP/libmetal
       - name: meta-openamp
         url: https://github.com/OpenAMP/meta-openamp
+      - name: lopper
+        url: https://github.com/devicetree-org/lopper
 # Custom Col on the right
 third-column:
     title: Useful Links


### PR DESCRIPTION
Add a link to the Lopper GitHub repo in the website footer, where the other
repo links are, since that is an OpenAMP System Device Tree working group
repository that lives in the devicetree-org project's GitHub.