### PR TITLE
Add blog post with ELCNA 2020 recording link

### DIFF
--- a/_posts/2020-10-03-elcna-presentation-recording.md
+++ b/_posts/2020-10-03-elcna-presentation-recording.md
@@ -1,0 +1,19 @@
+---
+title: Recording of OpenAMP presentation at ELC North America 2020
+author: openamp
+layout: post
+date: 2020-10-03 01:00:00
+description: >-
+  Nathalie C. Chan King Choy and Stefano Stabellini presented on OpenAMP at ELC North America 2020. The recording is now available on YouTube.
+categories:
+  - News
+tags:
+  - OpenAMP
+  - Presentation
+  - EmbeddedLinuxConference
+  - YouTube
+image: /assets/images/social-media-image.png
+---
+Nathalie C. Chan King Choy and Stefano Stabellini presented at the Embedded Linux Conference North America 2020 in July.  The presentation was The OpenAMP Project and its Working Groups: Standardizing the Interactions Between Operating Environments in a Heterogeneous Embedded System.  
+
+You can view the recording of the presentation [here on YouTube](https://youtu.be/rLWl4fLbIJI).


### PR DESCRIPTION
Nathalie and Stefano presented at ELCNA 2020. The recording is
now available on YouTube.  Make a blog post to share the link.