### PR TITLE
Use Linaro as the Copyright holder in webpage footer

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,5 +1,5 @@
 # Copyright text to be displayed at the very bottom of the footer
-copyright_text: OpenAMP Project
+copyright_text: Linaro
 # Set this to false if you do not want the Linaro logo in the footer.
 footer_brand:
   logo: /assets/images/Linaro-logo-white.png


### PR DESCRIPTION
Bill F. pointed out that Linaro is the legal entity.  That's what is used on the Trusted Firmware webpage footer copyright.