### PR TITLE
Publish code of conduct

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -33,3 +33,5 @@ second_column:
       url: https://lists.openampproject.org/mailman/listinfo
     - title: OpenAMP project governance
       url: /governance/
+    - title: OpenAMP code of conduct
+      url: /conduct/

--- a/_pages/conduct.md
+++ b/_pages/conduct.md
@@ -1,0 +1,83 @@
+---
+layout: flow
+title: Code of Conduct
+permalink: /conduct/
+description: |-
+  Code of conduct documented here.
+jumbotron:
+  title: OpenAMP Code of Conduct
+  class: openamp_bg overlay flex-column expandable_jumbotron background-image
+  image: /assets/images/content/triangle_background.png
+---
+
+# Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+# Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+# Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+# Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+# Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the OpenAMP Code of Conduct Team at openamp-coc@lists.openampproject.org. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The conduct team will make every effort to hear and understand all parties in the dispute. The conduct team is obligated to maintain confidentiality with regard to the reporter of an incident. Confidentiality of the person in violation and the nature of the violation will be maintained until action is agreed to. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+We will respect confidentiality requests for the purpose of protecting victims of unacceptable behavior. At our discretion, we may publicly name a person about whom we’ve received unacceptable behavior complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of OpenAMP members or the general public. We will not name victims without their affirmative consent.
+
+Any action by the conduct team must be agreed by a majority of the members.  The conduct team will inform the person in violation of the intended action before taking action but the action will proceed with or without acknowledgment.
+
+The OpenAMP Code of Conduct Team will report on a yearly basis the number of incidence reports. The OpenAMP Code of Conduct Team shall consist of three members elected by the community every two years or when needed.
+
+# Who to Contact
+
+The following people comprise the OpenAMP Code of Conduct Team and are the only recipients of openamp-coc@lists.openampproject.org:
+* Tomas Evensen
+* Bill Mills
+* Jeffrey Hancock
+
+# Attribution
+This code is based on the CHAOSS Community Code of Conduct v1.2 available at https://chaoss.community/about/code-of-conduct/
+
+The CHAOSS code is adapted from from the Contributor Covenant, version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html and the Geek Feminism Code of Conduct, available at https://geekfeminism.org/about/code-of-conduct/
+
+# Version History
+## v1.0
+* Add names based on TSC meeting, 2021-10-23
+## v0.9: Policy Changes and Clarifications, 2021-01-29
+* Clarified that it is the Conduct Team that maintains the required confidentiality
+* Clarified that the Conduct Team will attempt to hear and understand all parties in the dispute
+* Require confidentiality for the person in violation until the Conduct Team decides to take action
+* Clarified that actions are taken only after the Conduct Team has discussed and voted on the incident and action.
+* Stated that the person in violation be informed of all actions taken
+## v0.8: Changes to adapt to OpenAMP
+* Change CHAOSS references OpenAMP
+* Change email list name
+* Change team members to place holders for now
+* Updated Attribution
+* Updated this Version History
+## V0.0
+* Import CHAOSS CoC v1.2

--- a/_pages/conduct.md
+++ b/_pages/conduct.md
@@ -42,7 +42,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 # Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the OpenAMP Code of Conduct Team at openamp-coc@lists.openampproject.org. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The conduct team will make every effort to hear and understand all parties in the dispute. The conduct team is obligated to maintain confidentiality with regard to the reporter of an incident. Confidentiality of the person in violation and the nature of the violation will be maintained until action is agreed to. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the OpenAMP Code of Conduct Team at [openamp-coc@lists.openampproject.org](mailto:openamp-coc@lists.openampproject.org). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The conduct team will make every effort to hear and understand all parties in the dispute. The conduct team is obligated to maintain confidentiality with regard to the reporter of an incident. Confidentiality of the person in violation and the nature of the violation will be maintained until action is agreed to. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 
@@ -54,30 +54,34 @@ The OpenAMP Code of Conduct Team will report on a yearly basis the number of inc
 
 # Who to Contact
 
-The following people comprise the OpenAMP Code of Conduct Team and are the only recipients of openamp-coc@lists.openampproject.org:
+The following people comprise the OpenAMP Code of Conduct Team and are the only recipients of [openamp-coc@lists.openampproject.org](mailto:openamp-coc@lists.openampproject.org):
 * Tomas Evensen
 * Bill Mills
 * Jeffrey Hancock
 
 # Attribution
-This code is based on the CHAOSS Community Code of Conduct v1.2 available at https://chaoss.community/about/code-of-conduct/
+This code is based on the CHAOSS Community Code of Conduct v1.2 available at [https://chaoss.community/about/code-of-conduct/](https://chaoss.community/about/code-of-conduct/)
 
-The CHAOSS code is adapted from from the Contributor Covenant, version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html and the Geek Feminism Code of Conduct, available at https://geekfeminism.org/about/code-of-conduct/
+The CHAOSS code is adapted from from the Contributor Covenant, version 1.4, available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html) and the Geek Feminism Code of Conduct, available at [https://geekfeminism.org/about/code-of-conduct/](https://geekfeminism.org/about/code-of-conduct/)
 
 # Version History
+
 ## v1.0
 * Add names based on TSC meeting, 2021-10-23
+
 ## v0.9: Policy Changes and Clarifications, 2021-01-29
 * Clarified that it is the Conduct Team that maintains the required confidentiality
 * Clarified that the Conduct Team will attempt to hear and understand all parties in the dispute
 * Require confidentiality for the person in violation until the Conduct Team decides to take action
 * Clarified that actions are taken only after the Conduct Team has discussed and voted on the incident and action.
 * Stated that the person in violation be informed of all actions taken
+
 ## v0.8: Changes to adapt to OpenAMP
 * Change CHAOSS references OpenAMP
 * Change email list name
 * Change team members to place holders for now
 * Updated Attribution
 * Updated this Version History
+
 ## V0.0
 * Import CHAOSS CoC v1.2

--- a/_pages/governance.md
+++ b/_pages/governance.md
@@ -210,4 +210,4 @@ TBD
 [libmetal github]: https://github.com/OpenAMP/libmetal
 [open-amp github]: https://github.com/OpenAMP/open-amp
 [zephyr coding style]: https://docs.zephyrproject.org/latest/contribute/index.html#coding-style
-[code of conduct]: https://www.openampproject.org/conduct
+[code of conduct]: https://www.openampproject.org/

--- a/_pages/governance.md
+++ b/_pages/governance.md
@@ -56,9 +56,7 @@ Initial discussion at [October 2020 TSC call](https://github.com/OpenAMP/open-am
 
 # Code of Conduct
 
-The OpenAMP Board is in the process of working on a modified version of the CHAOSS code of conduct. That will need to be voted upon to be adopted.
-
-We are looking for a couple volunteers to be part of the Code of Conduct Committee. Please contact [the board](mailto:board@lists.openampproject.org "E-mail OpenAMP Board") if you are interested.
+Published at the OpenAMP [code of conduct][code of conduct] page.
 
 # Development Process
 
@@ -212,3 +210,4 @@ TBD
 [libmetal github]: https://github.com/OpenAMP/libmetal
 [open-amp github]: https://github.com/OpenAMP/open-amp
 [zephyr coding style]: https://docs.zephyrproject.org/latest/contribute/index.html#coding-style
+[code of conduct]: https://www.openampproject.org/conduct


### PR DESCRIPTION
OpenAMP Board approved the code of conduct proposed by Bill Mills on 2/17/21 in an email vote.  OpenAMP TSC finalized the membership of the first code of conduct committee at the OpenAMP TSC meeting on 10/23/21.