### PR TITLE
Update governance.md link to code of conduct

### DIFF
--- a/_pages/governance.md
+++ b/_pages/governance.md
@@ -210,4 +210,4 @@ TBD
 [libmetal github]: https://github.com/OpenAMP/libmetal
 [open-amp github]: https://github.com/OpenAMP/open-amp
 [zephyr coding style]: https://docs.zephyrproject.org/latest/contribute/index.html#coding-style
-[code of conduct]: https://www.openampproject.org/
+[code of conduct]: https://www.openampproject.org/conduct


### PR DESCRIPTION
Now that the page exists, it can be linked from the governance page without making the pull request checker fail.