### PR TITLE
update checkoout action to V3

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -14,7 +14,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           path: website

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: website
 


### PR DESCRIPTION
Node.js 12 actions are deprecated. Use the checkout V3 action to use Node.js 16