### PR TITLE
Make it easier to get started with OpenAMP

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -120,10 +120,13 @@ avatar_placeholder: /assets/images/avatar-placeholder.jpg
 post_placeholder: /assets/images/content/linaro-logo.png
 # Social Media Links
 social_media_channels:
-  github: false
-  linkedin: false
+  github:
+    url: https://github.com/OpenAMP
+  linkedin:
+    url: https://www.linkedin.com/company/openamp
   facebook: false
-  youtube: false
+  youtube:
+    url: https://youtube.com/@openamp
   twitter: false
   instagram: false
 # Disqus Comments Setup

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -4,7 +4,7 @@ copyright_text: Linaro
 footer_brand:
   logo: /assets/images/Linaro-logo-white.png
 # Social Media Icons Row
-social-media-icons: false
+social-media-icons: true
 # Display the contact details section
 display-contact-details: false
 # These links are displayed at the very bottom of the footer.

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -14,23 +14,21 @@ company_links:
   - name: Contact
     url: https://www.linaro.org/contact/
 first_column:
-  title: GitHub Projects
+  title: Getting Started
   items:
-    - title: open-amp
-      url: https://github.com/OpenAMP/open-amp
-    - title: libmetal
-      url: https://github.com/OpenAMP/libmetal
-    - title: meta-openamp
-      url: https://github.com/OpenAMP/meta-openamp
-    - title: lopper
-      url: https://github.com/devicetree-org/lopper
+    - title: OpenAMP Project documentation
+      url: https://openamp.readthedocs.io/en/latest/index.html
+    - title: Reference samples and demos
+      url: https://openamp.readthedocs.io/en/latest/demos/index.html
+    - title: OpenAMP mailing lists
+      url: https://lists.openampproject.org/mailman3/lists/?all-lists
+    - title: OpenAMP community Discord
+      url: https://discord.gg/8quFQBWq42
 second_column:
   title: Useful Links
   items:
     - title: OpenAMP call meeting notes
       url: https://github.com/OpenAMP/open-amp/wiki#Meeting_Notes
-    - title: OpenAMP mailing lists
-      url: https://lists.openampproject.org/mailman3/lists/?all-lists
     - title: OpenAMP project governance
       url: /governance/
     - title: OpenAMP code of conduct

--- a/_includes/openamp-jumbotron.html
+++ b/_includes/openamp-jumbotron.html
@@ -13,7 +13,7 @@
     </div>
     <div class="col col-12 no-padding">
         <p id="buttons">
-            <a class="btn btn-primary" href="https://github.com/OpenAMP/open-amp" role="button" target="_blank">
+            <a class="btn btn-primary" href="https://github.com/OpenAMP" role="button" target="_blank">
                 View on Github <i class="fa fa-github"></i>
             </a>
         </p>


### PR DESCRIPTION
Address the suggestions in issue #97 and also fix the jumbotron button to point to the GitHub organization instead of just the OpenAMP library.