### PR TITLE
Add YouTube video to webinar resources blog post

### DIFF
--- a/_posts/2023-01-18-system-ref-webinar-available.md
+++ b/_posts/2023-01-18-system-ref-webinar-available.md
@@ -36,5 +36,5 @@ Speakers and Panelists:
 * Tammy Leino, Software Engineer, Siemens
 
 
-The Linaro resource page with the video of the presentation and the slides can be found [here](https://resources.linaro.org/en/resource/2QSzYLK9Uxq4CFhVBYAnvb).
+The video of the presentation and the slides can be found [at this Linaro resource page](https://resources.linaro.org/en/resource/2QSzYLK9Uxq4CFhVBYAnvb).
 In the posted slides are links to the documentation and repositories for reproducing the demos, as well as a link to join the OpenAMP community Discord channel.

--- a/_posts/2023-01-18-system-ref-webinar-available.md
+++ b/_posts/2023-01-18-system-ref-webinar-available.md
@@ -37,5 +37,5 @@ Speakers and Panelists:
 
 
 The video of the presentation and the slides can be found [at this Linaro resource page](https://resources.linaro.org/en/resource/2QSzYLK9Uxq4CFhVBYAnvb).
-A [YouTube version of the video](https://youtu.be/R_5DOIvo7tI) is also available, with chapter links so you can jump to specific sections easily.
 In the posted slides are links to the documentation and repositories for reproducing the demos, as well as a link to join the OpenAMP community Discord channel.
+A [YouTube version of the video](https://youtu.be/R_5DOIvo7tI) is also available, with chapter links so you can jump to specific sections easily.

--- a/_posts/2023-01-18-system-ref-webinar-available.md
+++ b/_posts/2023-01-18-system-ref-webinar-available.md
@@ -37,4 +37,5 @@ Speakers and Panelists:
 
 
 The video of the presentation and the slides can be found [at this Linaro resource page](https://resources.linaro.org/en/resource/2QSzYLK9Uxq4CFhVBYAnvb).
+A [YouTube version of the video](https://youtu.be/R_5DOIvo7tI) is also available, with chapter links so you can jump to specific sections easily.
 In the posted slides are links to the documentation and repositories for reproducing the demos, as well as a link to join the OpenAMP community Discord channel.


### PR DESCRIPTION
We posted to YouTube with the chapter links after this blog post went out, but it's helpful to have it referenced here.  Adding the link to the YouTube video on our OpenAMP channel.