### PR TITLE
Create blog post for LHR23 AMP BOF

### DIFF
--- a/_posts/2023-05-17-LHR23-BOF-available.md
+++ b/_posts/2023-05-17-LHR23-BOF-available.md
@@ -1,0 +1,30 @@
+---
+title: Check out Resources from AMP BOF at Linaro Connect LHR23
+author: openamp
+layout: post
+date: 2023-01-18 12:00:00
+description: >-
+  The LHR23 AMP BOF slides and recording are posted to the Linaro resources page.
+category: news
+tags:
+  - HPP
+  - AMP
+  - BOF
+  - Linaro Connect
+image: /assets/images/content/openAMP_share_image.png
+---
+The Heterogenous Processing Project (HPP) and OpenAMP System Reference working group held a Birds of Feather discussion at Linaro Connect LHR23 on April 27, 2023.  
+
+This BOF was open to discussions about all things AMP. Many modern SOCs contain multiple CPU types. Many system solutions use multiple different operating systems like Linux + RTOS.
+
+The presentation consisted of a short introduction and status update, followed by open discussion with the audience. All topics related to this scope were welcome.
+
+Speakers and Panelists:
+* Bill Mills, Principal Technical Consultant, Linaro
+* Arnaud Pouliquen, Design S/W Senior Engineer, STMicroelectronics
+* Tomas Evensen, Senior Fellow Open Source Program Office, AMD Xilinx
+* Dan Milea, Technology Office, Wind River
+* Mathieu Poirier, Kernel Maintainer, Linaro
+* Nathalie Chan King Choy, Open Source Program Manager, AMD Xilinx
+
+The video of the presentation and the slides can be found [at this Linaro resource page](https://resources.linaro.org/en/resource/ivxrQF2tyyQcQEoBCkMCM4).

--- a/_posts/2023-05-17-LHR23-BOF-available.md
+++ b/_posts/2023-05-17-LHR23-BOF-available.md
@@ -19,7 +19,7 @@ This BOF was open to discussions about all things AMP. Many modern SOCs contain 
 
 The presentation consisted of a short introduction and status update, followed by open discussion with the audience. All topics related to this scope were welcome.
 
-Speakers and Panelists:
+Discussion leads:
 * Bill Mills, Principal Technical Consultant, Linaro
 * Arnaud Pouliquen, Design S/W Senior Engineer, STMicroelectronics
 * Tomas Evensen, Senior Fellow Open Source Program Office, AMD Xilinx

--- a/_posts/2023-05-17-LHR23-BOF-available.md
+++ b/_posts/2023-05-17-LHR23-BOF-available.md
@@ -2,7 +2,7 @@
 title: Check out Resources from AMP BOF at Linaro Connect LHR23
 author: openamp
 layout: post
-date: 2023-01-18 12:00:00
+date: 2023-05-17 23:00:00
 description: >-
   The LHR23 AMP BOF slides and recording are posted to the Linaro resources page.
 category: news


### PR DESCRIPTION
To make it easy to look up later, let's make sure the LHR23 AMP BOF resources go in the OpenAMP Blog.